### PR TITLE
Quit game from menu instead of transitioning to main menu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This document lists the new features, improvements, changes, and bug fixes in ea
 
 ## Changes
 
+- Updated QuitMenu to quit the game instead of reseting to the main menu.
 - Refactored the mini-map's code to remove coupling.
 - Simplified some code, renamed variables for clarity.
 

--- a/project/src/UI/UI.gd
+++ b/project/src/UI/UI.gd
@@ -8,8 +8,8 @@ onready var quit_menu := $QuitMenu
 
 
 func _ready() -> void:
-	Events.connect("player_died", self, "quit", [true])
-	Events.connect("quit_requested", self, "quit", [false])
+	Events.connect("player_died", self, "reset", [true])
+	Events.connect("quit_requested", self, "quit")
 	Events.connect("upgrade_unlocked", upgrade_menu, "open")
 	screen_fader.fade_in()
 
@@ -24,7 +24,11 @@ func _unhandled_input(event: InputEvent) -> void:
 		map.toggle()
 
 
-func quit(with_delay: bool) -> void:
+func quit() -> void:
+	get_tree().quit()
+
+
+func reset(with_delay: bool) -> void:
 	screen_fader.fade_out(with_delay)
 	yield(screen_fader, "animation_finished")
 	get_tree().change_scene("res://src/UI/MainMenu.tscn")


### PR DESCRIPTION
When `quit_requested` is emitted from the QuitMenu, the UI closes the game. The `player_died` method now calls `reset`, which transitions back to the MainMenu same as before.

This fixes issue #29.

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [x] You updated the docs or changelog.


Related issue (if applicable): #29

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**



**Does this PR introduce a breaking change?**



## New feature or change ##


**What is the current behavior?** 



**What is the new behavior?**



**Other information**
