### PR TITLE
Fix keyboard input in UpgradeMenu

### DIFF
--- a/project/src/UI/Upgrades/UpgradeButton.tscn
+++ b/project/src/UI/Upgrades/UpgradeButton.tscn
@@ -6,16 +6,9 @@
 [ext_resource path="res://assets/ui/fonts/default_font_bold.tres" type="DynamicFont" id=5]
 [ext_resource path="res://src/UI/Upgrades/UpgradeButton.gd" type="Script" id=6]
 
-
-
-
-
-
 [node name="UpgradeButton" type="TextureButton"]
 margin_right = 128.0
 margin_bottom = 128.0
-focus_neighbour_left = NodePath("../WeaponUpgrade")
-focus_neighbour_right = NodePath("../SpeedUpgrade")
 texture_normal = ExtResource( 2 )
 texture_pressed = ExtResource( 3 )
 texture_hover = ExtResource( 4 )

--- a/project/src/UI/Upgrades/UpgradeMenu.tscn
+++ b/project/src/UI/Upgrades/UpgradeMenu.tscn
@@ -8,13 +8,6 @@
 [ext_resource path="res://src/UI/Upgrades/UpgradeButton.tscn" type="PackedScene" id=6]
 [ext_resource path="res://assets/ui/icons/upgrades/mining_upgrade.svg" type="Texture" id=7]
 
-
-
-
-
-
-
-
 [node name="UpgradeMenu" type="Control"]
 anchor_right = 1.0
 anchor_bottom = 1.0


### PR DESCRIPTION
Removes focus_neighbour*-s from UpgradeButton,
so that the engine can handle neighbour focusing.
Also, are the empty lines there on purpose?

Closes #34 