### PR TITLE
If enemy hurt, send aggro signal

### DIFF
--- a/project/src/Ships/Enemies/Pirate/PirateShip.gd
+++ b/project/src/Ships/Enemies/Pirate/PirateShip.gd
@@ -133,6 +133,9 @@ func _on_self_damaged(target: Node, amount: int, _origin: Node) -> void:
 
 	_health -= amount
 
+	if _origin:
+		Events.emit_signal("target_aggroed", squad_leader, _origin)
+
 	if _health <= 0:
 		_die()
 


### PR DESCRIPTION
This sends a signal if an enemy gets shot at that they should move
into attack mode. Closes #40.

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.
